### PR TITLE
[#3] Added an akvo config with the Keycloak url

### DIFF
--- a/k8s/config/dev.yaml
+++ b/k8s/config/dev.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: akvo
+  namespace: default
+data:
+  keycloak.url: https://kc.akvotest.org/auth

--- a/k8s/config/prod.yaml
+++ b/k8s/config/prod.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: akvo
+  namespace: default
+data:
+  keycloak.url: https://login.akvo.org/auth


### PR DESCRIPTION
Created config maps. I tried to follow the scheme with dots from https://kubernetes.io/docs/user-guide/configmap/ . Hence an Akvo config and not a separate Keycloak one. Hope that makes sense.