### PR TITLE
[#27] Configure CPU limits for Keycloak deployment

### DIFF
--- a/k8s/keycloak-ha-mysql/deployment.yaml
+++ b/k8s/keycloak-ha-mysql/deployment.yaml
@@ -14,8 +14,12 @@ spec:
         image: akvo/keycloak-ha-mysql:52ef8389
         imagePullPolicy: Always
         resources:
+          requests:
+            memory: "650m"
+            cpu: "50m"
           limits:
             memory: "1G"
+            cpu: "1000m"
         ports:
         - containerPort: 8080
         readinessProbe:


### PR DESCRIPTION
Setting min to 5% CPU and max to 1 CPU

Specifying request memory as by default it uses the limit memory, which means the pod is never scheduled