### PR TITLE
[#177] lumen.api.authz.probability set to 0.1

### DIFF
--- a/k8s/config/prod.yaml
+++ b/k8s/config/prod.yaml
@@ -11,4 +11,4 @@ data:
   flow.api.auth0.root: https://api-auth0.akvo.org/flow
   flow.api.root: https://api.akvo.org/flow
   keycloak.url: https://login.akvo.org/auth
-  lumen.api.authz.probability: "0.0"
+  lumen.api.authz.probability: "0.1"


### PR DESCRIPTION
Enable 0.1 probability of backchannel traffic to Keycloak in production. This should dashboard at https://metrics.akvo.org/d/4z-8F0cWz/calls-to-auth-allowed-paths?orgId=1 a bit more populated.