### PR TITLE
Add auth.end.session.endpoint.suffix

### DIFF
--- a/k8s/config/dev.yaml
+++ b/k8s/config/dev.yaml
@@ -7,6 +7,7 @@ data:
   auth.url: https://akvotest.eu.auth0.com/
   auth.public.client.id: D5LayiXP1pzq-6g2B_QVvzCw_eycZxQK
   auth.rsa.suffix.url: .well-known/jwks.json
+  auth.end.session.endpoint.suffix: v2/logout
   email.host: mail.akvo.org
   environment: test
   flow.api.root: https://api-auth0.akvotest.org/flow

--- a/k8s/config/prod.yaml
+++ b/k8s/config/prod.yaml
@@ -7,6 +7,7 @@ data:
   auth.url: https://akvofoundation.eu.auth0.com/
   auth.public.client.id: 7Ze0JP6Jjf7zItGy3ekyuTvwGyik4Lay
   auth.rsa.suffix.url: .well-known/jwks.json
+  auth.end.session.endpoint.suffix: v2/logout
   email.host: mail.akvo.org
   environment: production
   flow.api.root: https://api-auth0.akvo.org/flow


### PR DESCRIPTION
Thus Auth0 doesn't provide this url on https://akvotest.eu.auth0.com/.well-known/openid-configuration

Although lumen specifies this value as a default, lumen deployment.yaml.template requires it too


