### PR TITLE
Increase backend timeout

### DIFF
--- a/k8s/ingress/ci/deploy.sh
+++ b/k8s/ingress/ci/deploy.sh
@@ -32,7 +32,9 @@ gcloud config set container/use_client_certificate True
 log Environment is test
 gcloud container clusters get-credentials test
 kubectl apply -f test.yaml
+kubectl apply -f timeout-backend-config.yaml
 
 log Environment is production
 gcloud container clusters get-credentials production
 kubectl apply -f prod.yaml
+kubectl apply -f timeout-backend-config.yaml

--- a/k8s/ingress/timeout-backend-config.yaml
+++ b/k8s/ingress/timeout-backend-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: timeout-backendconfig
+spec:
+  timeoutSec: 100


### PR DESCRIPTION
lumen exporter service needs more than the 30s timeout default value
relates https://github.com/akvo/akvo-lumen/issues/2591